### PR TITLE
Reset OnLateTick in TickRunner disposal

### DIFF
--- a/Assets/_Project/Scripts/Runtime/Gameplay/TickRunner.cs
+++ b/Assets/_Project/Scripts/Runtime/Gameplay/TickRunner.cs
@@ -74,11 +74,12 @@ namespace IdleCastle.Runtime.Gameplay
 
 		public void Resume () => _isPaused = false;
 
-		public void Dispose ()
-		{
-			OnTick      = null;
-			OnShortTick = null;
-			OnLongTick  = null;
-		}
-	}
+                public void Dispose ()
+                {
+                        OnTick      = null;
+                        OnLateTick  = null;
+                        OnShortTick = null;
+                        OnLongTick  = null;
+                }
+        }
 }


### PR DESCRIPTION
## Summary
- reset `OnLateTick` in `TickRunner.Dispose` to release subscribers

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed; 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6897380bf1d4832a972c7b40837b259e